### PR TITLE
cockpit: Put "root: true" into eslintrc

### DIFF
--- a/cockpit/.eslintrc.json
+++ b/cockpit/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "browser": true,
         "es6": true

--- a/cockpit/package.json
+++ b/cockpit/package.json
@@ -35,7 +35,7 @@
     "jshint": "~2.9.1",
     "jshint-loader": "~0.8.3",
     "less": "^3.8.0",
-    "less-loader": "^4.1.0",
+    "less-loader": "^5.0.0",
     "patternfly": "^3.27.4",
     "patternfly-react": "^0.8.0",
     "po2json": "^0.4.5",

--- a/integration-tests/run
+++ b/integration-tests/run
@@ -67,10 +67,14 @@ integration-test/common:
 	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 191
 	git archive FETCH_HEAD -- test/common | tar -x -C integration-tests --strip-components=1 -f -
 
-node_modules/%:
+node_modules:
+	mkdir node_modules
+
+node_modules/%: node_modules
 	npm install $*
 
 cockpit/node_modules:
+	mkdir cockpit/node_modules
 	cd cockpit/ && npm install
 
 .PHONY: check prepare reset


### PR DESCRIPTION
The Cockpit Integration Test machinery has recently started to check
out the repo into a place has a .eslintrc in one of the parent
directories.  This might be fixed soon, but "root: true" seems like a
good idea in general.