### PR TITLE
cockpit: Update bots target for moved GitHub project

### DIFF
--- a/integration-tests/run
+++ b/integration-tests/run
@@ -54,12 +54,14 @@ $(VM_IMAGE): $(COCKPIT_TAR) $(SUBMAN_TAR) $(SMBEXT_TAR) bots
           -u $(SMBEXT_TAR):/var/tmp/ \
           -s ./integration-tests/vm.install
 
-# checkout Cockpit's bots/ directory for standard test VM images and API to launch them
-# must be from cockpit's master, as only that has current and existing images; but testvm.py API is stable
+# checkout Cockpit's bots for standard test VM images and API to launch them
+# must be from master, as only that has current and existing images; but testvm.py API is stable
 bots:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git
-	git checkout --force FETCH_HEAD -- bots/
-	git reset bots
+	if [ ! -d bots ]; then \
+		git clone --depth=1 https://github.com/cockpit-project/bots.git; \
+	else \
+		cd bots && git fetch && git reset --hard origin/master; \
+        fi
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
@@ -77,4 +79,4 @@ cockpit/node_modules:
 	mkdir cockpit/node_modules
 	cd cockpit/ && npm install
 
-.PHONY: check prepare reset
+.PHONY: check prepare reset bots


### PR DESCRIPTION
Cockpit bots are in their own project now.

Make the target phony so that `make bots` updates an existing checkout.